### PR TITLE
Add close method to Tag instance

### DIFF
--- a/lib/wahwah/tag.rb
+++ b/lib/wahwah/tag.rb
@@ -45,6 +45,14 @@ module WahWah
       end
     end
 
+    def close
+      @file_io.close
+    end
+
+    def closed?
+      @file_io.closed?
+    end
+
     def inspect
       inspect_id = ::Kernel.format '%x', (object_id * 2)
       inspect_attributes_values = INSPECT_ATTRIBUTES.map { |attr_name| "#{attr_name}=#{self.send(attr_name)}" }.join(' ')

--- a/test/wahwah/tag_test.rb
+++ b/test/wahwah/tag_test.rb
@@ -52,4 +52,20 @@ class WahWah::TagTest < Minitest::Test
       assert_includes tag_inspect, "#{attr_name}="
     end
   end
+
+  def test_closed
+    io = StringIO.new()
+    io.close
+    tag = SubTag.new(io)
+
+    assert tag.closed?
+  end
+
+  def test_close
+    io = StringIO.new()
+    tag = SubTag.new(io)
+    tag.close
+
+    assert io.closed?
+  end
 end


### PR DESCRIPTION
File's are opened when given a path to `WahWah::Tag`, which is enforced by `WahWah.open` by using `to_str`, but provides no mechanism to close said file. This can prove problematic when dealing with many files as OS's do pose open file limits. This change adds the ability to close `@file_io` which passes that responsibility onto the caller.