### PR TITLE
Support an already opened file as argument to WahWah::open

### DIFF
--- a/lib/wahwah.rb
+++ b/lib/wahwah.rb
@@ -60,35 +60,35 @@ module WahWah
     Mp4Tag: ["m4a"]
   }.freeze
 
-  def self.open(file)
-    opened = false
-    # `Pathname`s respond to :read, but we still want to open them.
-    if !file.respond_to?(:read) || file.respond_to?(:open)
-      file = file.to_path if file.respond_to? :to_path
-      file = file.to_str
-      raise WahWahArgumentError, "File is not exists" unless File.exist? file
-      raise WahWahArgumentError, "File is unreadable" unless File.readable? file
-      raise WahWahArgumentError, "File is empty" unless File.size(file) > 0
-      file = File.open file, "rb"
-      opened = true
-    end
+  def self.open(path_or_io)
+    with_io path_or_io do |io|
+      file_format = Helper.file_format io
 
-    begin
-      file_format = Helper.file_format(file)
-      # Falling back on the extension only enables invalid files to be loaded
-      # (for backwards API compatibility).
-      file_format ||= file.respond_to?(:path) ? File.extname(file.path).downcase[1..] : nil
       raise WahWahArgumentError, "No supported format found" unless support_formats.include? file_format
 
       FORMATE_MAPPING.each do |tag, formats|
-        break const_get(tag).new(file) if formats.include?(file_format)
+        break const_get(tag).new(io) if formats.include?(file_format)
       end
-    ensure
-      file.close if opened
     end
   end
 
   def self.support_formats
     FORMATE_MAPPING.values.flatten
+  end
+
+  private_class_method
+  def self.with_io(path_or_io, &block)
+    path_or_io = Pathname.new path_or_io if path_or_io.respond_to? :to_str
+
+    if path_or_io.is_a? Pathname
+      raise WahWahArgumentError, "File does not exist" unless File.exist? path_or_io
+      raise WahWahArgumentError, "File is unreadable" unless File.readable? path_or_io
+      raise WahWahArgumentError, "File is empty" unless File.size(path_or_io) > 0
+
+      path_or_io.open(&block)
+    else
+
+      block.call path_or_io
+    end
   end
 end

--- a/lib/wahwah/helper.rb
+++ b/lib/wahwah/helper.rb
@@ -25,17 +25,34 @@ module WahWah
       string.split(Regexp.new(('\x00' * terminator_size).b), 2)
     end
 
-    def self.file_format(file)
-      file.seek(0)
-      signature = file.read(16)
+    def self.file_format(io)
+      if io.respond_to?(:path) && io.path && !io.path.empty?
+        file_format = file_format_from_extension io.path
+        # Using OpenURI, the file *has* a path, but it's without an extension.
+        # To support that case, we fall back on signature detection.
+        file_format = file_format_from_signature io if file_format.empty?
+      else
+        file_format = file_format_from_signature io
+      end
+      file_format
+    end
+
+    def self.file_format_from_extension(file_path)
+      File.extname(file_path).downcase[1..]
+    end
+
+    def self.file_format_from_signature(io)
+      io.rewind
+      signature = io.read(16)
+
+      # Source: https://en.wikipedia.org/wiki/List_of_file_signatures
 
       # M4A is checked for first, since MP4 files start with a chunk size -
       # and that chunk size may incidentally match another signature.
       # No other formats would reasonably have "ftyp" as the next for bytes.
-      return "m4a" if signature[4...8] == "ftyp".b && signature[8...12] == "M4A ".b
+      return "m4a" if signature[4...12] == "ftypM4A ".b
       # Handled separately simply because it requires two checks.
       return "wav" if signature.start_with?("RIFF".b) && signature[8...12] == "WAVE".b
-
       magic_numbers = {
         "fLaC".b => "flac",
         "\xFF\xFB".b => "mp3",

--- a/lib/wahwah/id3/v2_header.rb
+++ b/lib/wahwah/id3/v2_header.rb
@@ -17,7 +17,7 @@ module WahWah
       attr_reader :major_version, :size
 
       def initialize(file_io)
-        header_content = file_io.read(HEADER_SIZE)
+        header_content = file_io.read(HEADER_SIZE) || ""
         @id, @major_version, @flags, size_bits = header_content.unpack(HEADER_FORMAT) if header_content.size >= HEADER_SIZE
 
         return unless valid?

--- a/lib/wahwah/mp3_tag.rb
+++ b/lib/wahwah/mp3_tag.rb
@@ -50,9 +50,8 @@ module WahWah
     end
 
     def parse_id3_tag
-      @file_io.seek(0)
+      @file_io.rewind
       signature = @file_io.read(6)
-      @file_io.seek(0)
 
       if signature.start_with?("ID3".b)
         id3_v2_tag = ID3::V2.new(@file_io)

--- a/lib/wahwah/riff/chunk.rb
+++ b/lib/wahwah/riff/chunk.rb
@@ -37,7 +37,7 @@ module WahWah
       end
 
       def valid?
-        !@id.empty? && !@size.nil? && @size > 0
+        @id && !@id.empty? && !@size.nil? && @size > 0
       end
 
       private

--- a/lib/wahwah/tag.rb
+++ b/lib/wahwah/tag.rb
@@ -26,30 +26,18 @@ module WahWah
       :file_size
     )
 
-    def initialize(file)
-      # `Pathname`s respond to :read, but we still want to open them.
-      opened = if file.respond_to?(:read) && !file.respond_to?(:open)
-        @file_size = file.size
-        @file_io = file
-        false
-      else
-        @file_size = File.size(file)
-        @file_io = File.open(file, "rb")
-        true
-      end
+    def initialize(io)
+      @file_size = io.size
+      @file_io = io
 
-      begin
-        @comments = []
-        @images_data = []
+      @comments = []
+      @images_data = []
 
-        parse if @file_size > 0
+      parse if @file_size > 0
 
-        INTEGER_ATTRIBUTES.each do |attr_name|
-          value = instance_variable_get("@#{attr_name}")&.to_i
-          instance_variable_set("@#{attr_name}", value)
-        end
-      ensure
-        @file_io.close if opened
+      INTEGER_ATTRIBUTES.each do |attr_name|
+        value = instance_variable_get("@#{attr_name}")&.to_i
+        instance_variable_set("@#{attr_name}", value)
       end
     end
 

--- a/test/wahwah/asf_tag_test.rb
+++ b/test/wahwah/asf_tag_test.rb
@@ -4,23 +4,24 @@ require "test_helper"
 
 class WahWah::AsfTagTest < Minitest::Test
   def test_parse
-    tag = WahWah::AsfTag.new("test/files/test.wma")
+    File.open "test/files/test.wma", "rb" do |file|
+      tag = WahWah::AsfTag.new(file)
 
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 1, tag.disc
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal 8.033, tag.duration
-    assert_equal 192, tag.bitrate
-    assert_equal 44100, tag.sample_rate
-    assert_equal 16, tag.bit_depth
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert file_io_closed?(tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 1, tag.disc
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal 8.033, tag.duration
+      assert_equal 192, tag.bitrate
+      assert_equal 44100, tag.sample_rate
+      assert_equal 16, tag.bit_depth
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+    end
   end
 end

--- a/test/wahwah/flac_tag_test.rb
+++ b/test/wahwah/flac_tag_test.rb
@@ -4,66 +4,69 @@ require "test_helper"
 
 class WahWah::FlacTagTest < Minitest::Test
   def test_vorbis_comment_tag_file
-    tag = WahWah::FlacTag.new("test/files/vorbis_comment.flac")
-    image = tag.images.first
+    File.open "test/files/vorbis_comment.flac", "rb" do |file|
+      tag = WahWah::FlacTag.new(file)
+      image = tag.images.first
 
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 1, tag.disc
-    assert_equal 8.0, tag.duration
-    assert_equal 705, tag.bitrate
-    assert_equal 16, tag.bit_depth
-    assert_equal 44100, tag.sample_rate
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :cover_front, image[:type]
-    assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert file_io_closed?(tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 1, tag.disc
+      assert_equal 8.0, tag.duration
+      assert_equal 705, tag.bitrate
+      assert_equal 16, tag.bit_depth
+      assert_equal 44100, tag.sample_rate
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :cover_front, image[:type]
+      assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+    end
   end
 
   def test_id3_header_tag_file
-    tag = WahWah::FlacTag.new("test/files/id3_header.flac")
+    File.open "test/files/id3_header.flac", "rb" do |file|
+      tag = WahWah::FlacTag.new(file)
 
-    assert_equal "ID3", File.read("test/files/id3_header.flac", 3)
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 1, tag.disc
-    assert_equal 0.45351473922902497, tag.duration
-    assert_equal 705, tag.bitrate
-    assert_equal 16, tag.bit_depth
-    assert_equal 44100, tag.sample_rate
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert file_io_closed?(tag)
+      assert_equal "ID3", File.read("test/files/id3_header.flac", 3)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 1, tag.disc
+      assert_equal 0.45351473922902497, tag.duration
+      assert_equal 705, tag.bitrate
+      assert_equal 16, tag.bit_depth
+      assert_equal 44100, tag.sample_rate
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+    end
   end
 
   def test_invalid_tag_file
-    tag = WahWah::FlacTag.new("test/files/invalid_tag.flac")
+    File.open "test/files/invalid_tag.flac", "rb" do |file|
+      tag = WahWah::FlacTag.new(file)
 
-    assert_nil tag.title
-    assert_nil tag.artist
-    assert_nil tag.albumartist
-    assert_nil tag.composer
-    assert_nil tag.album
-    assert_nil tag.year
-    assert_nil tag.genre
-    assert_nil tag.track
-    assert_nil tag.disc
-    assert_equal 3.684716553287982, tag.duration
-    assert_equal 705, tag.bitrate
-    assert_equal 16, tag.bit_depth
-    assert_equal 44100, tag.sample_rate
-    assert file_io_closed?(tag)
+      assert_nil tag.title
+      assert_nil tag.artist
+      assert_nil tag.albumartist
+      assert_nil tag.composer
+      assert_nil tag.album
+      assert_nil tag.year
+      assert_nil tag.genre
+      assert_nil tag.track
+      assert_nil tag.disc
+      assert_equal 3.684716553287982, tag.duration
+      assert_equal 705, tag.bitrate
+      assert_equal 16, tag.bit_depth
+      assert_equal 44100, tag.sample_rate
+    end
   end
 end

--- a/test/wahwah/helper_test.rb
+++ b/test/wahwah/helper_test.rb
@@ -30,8 +30,21 @@ class WahWah::HelperTest < Minitest::Test
   end
 
   def test_file_format
-    assert_equal "mp3", WahWah::Helper.file_format("test_file.mp3")
-    assert_equal "mp3", WahWah::Helper.file_format("test/test_file.mp3")
+    expected_formats = {
+      "alac.m4a" => "m4a",
+      "id3v1.mp3" => "mp3",
+      "id3v24.mp3" => "mp3",
+      "vorbis_comment.flac" => "flac",
+      "vorbis_tag.ogg" => "ogg",
+      "id3v2.wav" => "wav",
+      "riff_info.wav" => "wav",
+      "test.wma" => "wma"
+    }
+    expected_formats.each do |filename, file_format|
+      File.open File.join("test/files", filename), "rb" do |file|
+        assert_equal file_format, WahWah::Helper.file_format(file), "Failed to recognize \"#{filename}\""
+      end
+    end
   end
 
   def test_byte_string_to_guid

--- a/test/wahwah/lazy_read_test.rb
+++ b/test/wahwah/lazy_read_test.rb
@@ -40,7 +40,7 @@ class WahWah::LazyReadTest < Minitest::Test
   end
 
   def test_get_data_when_file_io_closed
-    file_io = File.open("test/files/id3v1.mp3")
+    file_io = File.open "test/files/id3v1.mp3", "rb"
     tag = Tag.new(file_io)
     file_io.close
 

--- a/test/wahwah/mp3_tag_test.rb
+++ b/test/wahwah/mp3_tag_test.rb
@@ -4,170 +4,176 @@ require "test_helper"
 
 class WahWah::Mp3TagTest < Minitest::Test
   def test_id3v1_tag_file
-    tag = WahWah::Mp3Tag.new("test/files/id3v1.mp3")
+    File.open "test/files/id3v1.mp3", "rb" do |file|
+      tag = WahWah::Mp3Tag.new(file)
 
-    assert !tag.id3v2?
-    assert tag.is_vbr?
-    assert_equal "v1", tag.id3_version
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal 8.045714285714286, tag.duration
-    assert_equal 32, tag.bitrate
-    assert_equal "MPEG1", tag.mpeg_version
-    assert_equal "layer3", tag.mpeg_layer
-    assert_equal "Joint Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert !tag.id3v2?
+      assert tag.is_vbr?
+      assert_equal "v1", tag.id3_version
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal 8.045714285714286, tag.duration
+      assert_equal 32, tag.bitrate
+      assert_equal "MPEG1", tag.mpeg_version
+      assert_equal "layer3", tag.mpeg_layer
+      assert_equal "Joint Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_id3v22_tag_file
-    tag = WahWah::Mp3Tag.new("test/files/id3v22.mp3")
-    image = tag.images.first
+    File.open "test/files/id3v22.mp3", "rb" do |file|
+      tag = WahWah::Mp3Tag.new(file)
+      image = tag.images.first
 
-    assert tag.id3v2?
-    assert !tag.is_vbr?
-    assert_equal "v2.2", tag.id3_version
-    assert_equal "You Are The One", tag.title
-    assert_equal "Shiny Toy Guns", tag.artist
-    assert_nil tag.albumartist
-    assert_nil tag.composer
-    assert_equal "We Are Pilots", tag.album
-    assert_equal "2006", tag.year
-    assert_equal "Alternative", tag.genre
-    assert_equal 1, tag.track
-    assert_equal 11, tag.track_total
-    assert_nil tag.disc
-    assert_nil tag.disc_total
-    assert_equal "0", tag.comments.first
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :other, image[:type]
-    assert_equal binary_data("test/files/id3v22_cover.jpeg"), image[:data].strip
-    assert_equal 0.36354166666666665, tag.duration
-    assert_equal 192, tag.bitrate
-    assert_equal "MPEG1", tag.mpeg_version
-    assert_equal "layer3", tag.mpeg_layer
-    assert_equal "Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert tag.lyrics.start_with?("Black rose")
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert tag.id3v2?
+      assert !tag.is_vbr?
+      assert_equal "v2.2", tag.id3_version
+      assert_equal "You Are The One", tag.title
+      assert_equal "Shiny Toy Guns", tag.artist
+      assert_nil tag.albumartist
+      assert_nil tag.composer
+      assert_equal "We Are Pilots", tag.album
+      assert_equal "2006", tag.year
+      assert_equal "Alternative", tag.genre
+      assert_equal 1, tag.track
+      assert_equal 11, tag.track_total
+      assert_nil tag.disc
+      assert_nil tag.disc_total
+      assert_equal "0", tag.comments.first
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :other, image[:type]
+      assert_equal binary_data("test/files/id3v22_cover.jpeg"), image[:data].strip
+      assert_equal 0.36354166666666665, tag.duration
+      assert_equal 192, tag.bitrate
+      assert_equal "MPEG1", tag.mpeg_version
+      assert_equal "layer3", tag.mpeg_layer
+      assert_equal "Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert tag.lyrics.start_with?("Black rose")
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_id3v23_tag_file
-    tag = WahWah::Mp3Tag.new("test/files/id3v23.mp3")
-    image = tag.images.first
+    File.open "test/files/id3v23.mp3", "rb" do |file|
+      tag = WahWah::Mp3Tag.new(file)
+      image = tag.images.first
 
-    assert tag.id3v2?
-    assert tag.is_vbr?
-    assert_equal "v2.3", tag.id3_version
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 8, tag.track_total
-    assert_equal 1, tag.disc
-    assert_equal 1, tag.disc_total
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :cover_front, image[:type]
-    assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
-    assert_equal 8.045714285714286, tag.duration
-    assert_equal 32, tag.bitrate
-    assert_equal "MPEG1", tag.mpeg_version
-    assert_equal "layer3", tag.mpeg_layer
-    assert_equal "Joint Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert tag.id3v2?
+      assert tag.is_vbr?
+      assert_equal "v2.3", tag.id3_version
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 8, tag.track_total
+      assert_equal 1, tag.disc
+      assert_equal 1, tag.disc_total
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :cover_front, image[:type]
+      assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
+      assert_equal 8.045714285714286, tag.duration
+      assert_equal 32, tag.bitrate
+      assert_equal "MPEG1", tag.mpeg_version
+      assert_equal "layer3", tag.mpeg_layer
+      assert_equal "Joint Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_id3v24_tag_file
-    tag = WahWah::Mp3Tag.new("test/files/id3v24.mp3")
-    image = tag.images.first
+    File.open "test/files/id3v24.mp3", "rb" do |file|
+      tag = WahWah::Mp3Tag.new(file)
+      image = tag.images.first
 
-    assert tag.id3v2?
-    assert tag.is_vbr?
-    assert_equal "v2.4", tag.id3_version
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Custom Genre", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 8, tag.track_total
-    assert_equal 1, tag.disc
-    assert_equal 1, tag.disc_total
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :cover_front, image[:type]
-    assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
-    assert_equal 8.045714285714286, tag.duration
-    assert_equal 32, tag.bitrate
-    assert_equal "MPEG1", tag.mpeg_version
-    assert_equal "layer3", tag.mpeg_layer
-    assert_equal "Joint Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert tag.id3v2?
+      assert tag.is_vbr?
+      assert_equal "v2.4", tag.id3_version
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Custom Genre", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 8, tag.track_total
+      assert_equal 1, tag.disc
+      assert_equal 1, tag.disc_total
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :cover_front, image[:type]
+      assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
+      assert_equal 8.045714285714286, tag.duration
+      assert_equal 32, tag.bitrate
+      assert_equal "MPEG1", tag.mpeg_version
+      assert_equal "layer3", tag.mpeg_layer
+      assert_equal "Joint Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_id3v2_with_extented_tag_file
-    tag = WahWah::Mp3Tag.new("test/files/id3v2_extended_header.mp3")
+    File.open "test/files/id3v2_extended_header.mp3", "rb" do |file|
+      tag = WahWah::Mp3Tag.new(file)
 
-    assert tag.id3v2?
-    assert !tag.is_vbr?
-    assert_equal "v2.4", tag.id3_version
-    assert_equal "title", tag.title
-    assert_equal 0.4963125, tag.duration
-    assert_equal 128, tag.bitrate
-    assert_equal "MPEG2", tag.mpeg_version
-    assert_equal "layer3", tag.mpeg_layer
-    assert_equal "Single Channel", tag.channel_mode
-    assert_equal 22050, tag.sample_rate
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert tag.id3v2?
+      assert !tag.is_vbr?
+      assert_equal "v2.4", tag.id3_version
+      assert_equal "title", tag.title
+      assert_equal 0.4963125, tag.duration
+      assert_equal 128, tag.bitrate
+      assert_equal "MPEG2", tag.mpeg_version
+      assert_equal "layer3", tag.mpeg_layer
+      assert_equal "Single Channel", tag.channel_mode
+      assert_equal 22050, tag.sample_rate
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_vbri_header_file
-    tag = WahWah::Mp3Tag.new("test/files/vbri_header.mp3")
+    File.open "test/files/vbri_header.mp3", "rb" do |file|
+      tag = WahWah::Mp3Tag.new(file)
 
-    assert tag.id3v2?
-    assert tag.is_vbr?
-    assert_equal "v2.3", tag.id3_version
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 8, tag.track_total
-    assert_equal 1, tag.disc
-    assert_equal 1, tag.disc_total
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal 222.19755102040818, tag.duration
-    assert_equal 233, tag.bitrate
-    assert_equal "MPEG1", tag.mpeg_version
-    assert_equal "layer3", tag.mpeg_layer
-    assert_equal "Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert tag.id3v2?
+      assert tag.is_vbr?
+      assert_equal "v2.3", tag.id3_version
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 8, tag.track_total
+      assert_equal 1, tag.disc
+      assert_equal 1, tag.disc_total
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal 222.19755102040818, tag.duration
+      assert_equal 233, tag.bitrate
+      assert_equal "MPEG1", tag.mpeg_version
+      assert_equal "layer3", tag.mpeg_layer
+      assert_equal "Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_invalid_id3_file

--- a/test/wahwah/mp4/atom_test.rb
+++ b/test/wahwah/mp4/atom_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class WahWah::Mp4::AtomTest < Minitest::Test
   def test_find_atom
-    io = File.open("test/files/udta_meta.m4a")
+    io = File.open("test/files/udta_meta.m4a", "rb")
     atom = WahWah::Mp4::Atom.find(io, "moov", "udta")
 
     assert_equal "udta", atom.type
@@ -12,7 +12,7 @@ class WahWah::Mp4::AtomTest < Minitest::Test
   end
 
   def test_return_invalid_atom_when_not_found
-    io = File.open("test/files/udta_meta.m4a")
+    io = File.open("test/files/udta_meta.m4a", "rb")
     atom = WahWah::Mp4::Atom.find(io, "moov", "uuuu")
 
     assert_instance_of WahWah::Mp4::Atom, atom
@@ -35,7 +35,7 @@ class WahWah::Mp4::AtomTest < Minitest::Test
   end
 
   def test_find_child_atom_from_atom
-    io = File.open("test/files/udta_meta.m4a")
+    io = File.open("test/files/udta_meta.m4a", "rb")
     atom = WahWah::Mp4::Atom.find(io, "moov", "trak", "mdia")
     child_atom = atom.find("minf", "stbl", "stsd")
 
@@ -44,7 +44,7 @@ class WahWah::Mp4::AtomTest < Minitest::Test
   end
 
   def test_return_invalid_atom_when_not_found_from_atom
-    io = File.open("test/files/udta_meta.m4a")
+    io = File.open("test/files/udta_meta.m4a", "rb")
     atom = WahWah::Mp4::Atom.find(io, "moov", "trak", "mdia")
     child_atom = atom.find("minf", "stbl", "uuuu")
 
@@ -53,7 +53,7 @@ class WahWah::Mp4::AtomTest < Minitest::Test
   end
 
   def test_get_atom_children_atoms
-    io = File.open("test/files/udta_meta.m4a")
+    io = File.open("test/files/udta_meta.m4a", "rb")
     atom = WahWah::Mp4::Atom.find(io, "moov", "udta", "meta")
     children = atom.children
 

--- a/test/wahwah/mp4_tag_test.rb
+++ b/test/wahwah/mp4_tag_test.rb
@@ -4,88 +4,89 @@ require "test_helper"
 
 class WahWah::Mp4TagTest < Minitest::Test
   def test_parse_meta_on_udta_atom
-    file_path = "test/files/udta_meta.m4a"
-    tag = WahWah::Mp4Tag.new(file_path)
-    meta_atom = WahWah::Mp4::Atom.find(File.open(file_path), "moov", "udta", "meta")
-    image = tag.images.first
+    File.open "test/files/udta_meta.m4a", "rb" do |file|
+      tag = WahWah::Mp4Tag.new(file)
+      meta_atom = WahWah::Mp4::Atom.find(File.open(file.path, "rb"), "moov", "udta", "meta")
+      image = tag.images.first
 
-    assert meta_atom.valid?
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 8, tag.track_total
-    assert_equal 1, tag.disc
-    assert_equal 1, tag.disc_total
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :cover, image[:type]
-    assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
-    assert_equal 8.057324263038549, tag.duration
-    assert_equal 128, tag.bitrate
-    assert_equal 44100, tag.sample_rate
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert meta_atom.valid?
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 8, tag.track_total
+      assert_equal 1, tag.disc
+      assert_equal 1, tag.disc_total
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :cover, image[:type]
+      assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
+      assert_equal 8.057324263038549, tag.duration
+      assert_equal 128, tag.bitrate
+      assert_equal 44100, tag.sample_rate
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_parse_meta_on_moov_atom
-    file_path = "test/files/moov_meta.m4a"
-    tag = WahWah::Mp4Tag.new(file_path)
-    meta_atom = WahWah::Mp4::Atom.find(File.open(file_path), "moov", "meta")
-    udta_meta_atom = WahWah::Mp4::Atom.find(File.open(file_path), "moov", "udta", "meta")
-    image = tag.images.first
+    File.open "test/files/moov_meta.m4a", "rb" do |file|
+      tag = WahWah::Mp4Tag.new(file)
+      meta_atom = WahWah::Mp4::Atom.find(File.open(file.path, "rb"), "moov", "meta")
+      udta_meta_atom = WahWah::Mp4::Atom.find(File.open(file.path, "rb"), "moov", "udta", "meta")
+      image = tag.images.first
 
-    assert meta_atom.valid?
-    assert !udta_meta_atom.valid?
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 8, tag.track_total
-    assert_equal 1, tag.disc
-    assert_equal 1, tag.disc_total
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :cover, image[:type]
-    assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
-    assert_equal 285.04816326530613, tag.duration
-    assert_equal 256, tag.bitrate
-    assert_equal 44100, tag.sample_rate
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert_nil tag.bit_depth
-    assert file_io_closed?(tag)
+      assert meta_atom.valid?
+      assert !udta_meta_atom.valid?
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 8, tag.track_total
+      assert_equal 1, tag.disc
+      assert_equal 1, tag.disc_total
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :cover, image[:type]
+      assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
+      assert_equal 285.04816326530613, tag.duration
+      assert_equal 256, tag.bitrate
+      assert_equal 44100, tag.sample_rate
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+      assert_nil tag.bit_depth
+    end
   end
 
   def test_parse_alac_encoded
-    tag = WahWah::Mp4Tag.new("test/files/alac.m4a")
-    image = tag.images.first
+    File.open "test/files/alac.m4a", "rb" do |file|
+      tag = WahWah::Mp4Tag.new(file)
+      image = tag.images.first
 
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 1, tag.disc
-    assert_equal 8.0, tag.duration
-    assert_equal 3, tag.bitrate
-    assert_equal 16, tag.bit_depth
-    assert_equal 44100, tag.sample_rate
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :cover, image[:type]
-    assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
-    assert file_io_closed?(tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 1, tag.disc
+      assert_equal 8.0, tag.duration
+      assert_equal 3, tag.bitrate
+      assert_equal 16, tag.bit_depth
+      assert_equal 44100, tag.sample_rate
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :cover, image[:type]
+      assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
+    end
   end
 end

--- a/test/wahwah/ogg/packets_test.rb
+++ b/test/wahwah/ogg/packets_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class WahWah::Ogg::PacketsTest < Minitest::Test
   def setup
-    @packets = WahWah::Ogg::Packets.new(File.open("test/files/vorbis_tag.ogg"))
+    @packets = WahWah::Ogg::Packets.new(File.open("test/files/vorbis_tag.ogg", "rb"))
   end
 
   def test_packets_enumerable

--- a/test/wahwah/ogg/pages_test.rb
+++ b/test/wahwah/ogg/pages_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class WahWah::Ogg::PagesTest < Minitest::Test
   def setup
-    @pages = WahWah::Ogg::Pages.new(File.open("test/files/vorbis_tag.ogg"))
+    @pages = WahWah::Ogg::Pages.new(File.open("test/files/vorbis_tag.ogg", "rb"))
   end
 
   def test_pages_enumerable

--- a/test/wahwah/ogg_tag_test.rb
+++ b/test/wahwah/ogg_tag_test.rb
@@ -4,65 +4,68 @@ require "test_helper"
 
 class WahWah::OggTagTest < Minitest::Test
   def test_vorbis_tag_file
-    tag = WahWah::OggTag.new("test/files/vorbis_tag.ogg")
+    File.open "test/files/vorbis_tag.ogg", "rb" do |file|
+      tag = WahWah::OggTag.new(file)
 
-    assert_instance_of WahWah::Ogg::VorbisTag, tag.instance_variable_get(:@tag)
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 1, tag.disc
-    assert_equal 8.0, tag.duration
-    assert_equal 192, tag.bitrate
-    assert_equal 44100, tag.sample_rate
-    assert_nil tag.bit_depth
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert file_io_closed?(tag)
+      assert_instance_of WahWah::Ogg::VorbisTag, tag.instance_variable_get(:@tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 1, tag.disc
+      assert_equal 8.0, tag.duration
+      assert_equal 192, tag.bitrate
+      assert_equal 44100, tag.sample_rate
+      assert_nil tag.bit_depth
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+    end
   end
 
   def test_opus_tag_file
-    tag = WahWah::OggTag.new("test/files/opus_tag.opus")
+    File.open "test/files/opus_tag.opus", "rb" do |file|
+      tag = WahWah::OggTag.new(file)
 
-    assert_instance_of WahWah::Ogg::OpusTag, tag.instance_variable_get(:@tag)
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 1, tag.disc
-    assert_equal 8.000020833333334, tag.duration
-    assert_equal 2, tag.bitrate
-    assert_equal 48000, tag.sample_rate
-    assert_nil tag.bit_depth
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert file_io_closed?(tag)
+      assert_instance_of WahWah::Ogg::OpusTag, tag.instance_variable_get(:@tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 1, tag.disc
+      assert_equal 8.000020833333334, tag.duration
+      assert_equal 2, tag.bitrate
+      assert_equal 48000, tag.sample_rate
+      assert_nil tag.bit_depth
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+    end
   end
 
   def test_flac_tag_file
-    tag = WahWah::OggTag.new("test/files/flac_tag.oga")
+    File.open "test/files/flac_tag.oga", "rb" do |file|
+      tag = WahWah::OggTag.new(file)
 
-    assert_instance_of WahWah::Ogg::FlacTag, tag.instance_variable_get(:@tag)
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 1, tag.disc
-    assert_equal 8.0, tag.duration
-    assert_equal 705, tag.bitrate
-    assert_equal 44100, tag.sample_rate
-    assert_equal 16, tag.bit_depth
-    assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
-    assert file_io_closed?(tag)
+      assert_instance_of WahWah::Ogg::FlacTag, tag.instance_variable_get(:@tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 1, tag.disc
+      assert_equal 8.0, tag.duration
+      assert_equal 705, tag.bitrate
+      assert_equal 44100, tag.sample_rate
+      assert_equal 16, tag.bit_depth
+      assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
+    end
   end
 end

--- a/test/wahwah/riff_tag_test.rb
+++ b/test/wahwah/riff_tag_test.rb
@@ -4,63 +4,66 @@ require "test_helper"
 
 class WahWah::RiffTagTest < Minitest::Test
   def test_id3_tag_file
-    tag = WahWah::RiffTag.new("test/files/id3v2.wav")
-    image = tag.images.first
+    File.open "test/files/id3v2.wav", "rb" do |file|
+      tag = WahWah::RiffTag.new(file)
+      image = tag.images.first
 
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "Iggy Pop", tag.albumartist
-    assert_equal "Iggy Pop", tag.composer
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal 5, tag.track
-    assert_equal 8, tag.track_total
-    assert_equal 1, tag.disc
-    assert_equal 1, tag.disc_total
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal "image/jpeg", image[:mime_type]
-    assert_equal :cover_front, image[:type]
-    assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
-    assert_equal 8.001133947554926, tag.duration
-    assert_equal 1411, tag.bitrate
-    assert_equal "Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert_equal 16, tag.bit_depth
-    assert file_io_closed?(tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "Iggy Pop", tag.albumartist
+      assert_equal "Iggy Pop", tag.composer
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal 5, tag.track
+      assert_equal 8, tag.track_total
+      assert_equal 1, tag.disc
+      assert_equal 1, tag.disc_total
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal "image/jpeg", image[:mime_type]
+      assert_equal :cover_front, image[:type]
+      assert_equal binary_data("test/files/cover.jpeg"), image[:data].strip
+      assert_equal 8.001133947554926, tag.duration
+      assert_equal 1411, tag.bitrate
+      assert_equal "Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_equal 16, tag.bit_depth
+    end
   end
 
   def test_riff_info_tag_file
-    tag = WahWah::RiffTag.new("test/files/riff_info.wav")
+    File.open "test/files/riff_info.wav", "rb" do |file|
+      tag = WahWah::RiffTag.new(file)
 
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal 8.001133947554926, tag.duration
-    assert_equal 1411, tag.bitrate
-    assert_equal "Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert_equal 16, tag.bit_depth
-    assert file_io_closed?(tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal 8.001133947554926, tag.duration
+      assert_equal 1411, tag.bitrate
+      assert_equal "Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_equal 16, tag.bit_depth
+    end
   end
 
   def test_tag_that_riff_chunk_without_data_chunk
-    tag = WahWah::RiffTag.new("test/files/riff_chunk_without_data_chunk.wav")
+    File.open "test/files/riff_chunk_without_data_chunk.wav", "rb" do |file|
+      tag = WahWah::RiffTag.new(file)
 
-    assert_equal "China Girl", tag.title
-    assert_equal "Iggy Pop", tag.artist
-    assert_equal "The Idiot", tag.album
-    assert_equal "1977", tag.year
-    assert_equal "Rock", tag.genre
-    assert_equal ["Iggy Pop Rocks"], tag.comments
-    assert_equal 8, tag.duration.round
-    assert_equal 1411, tag.bitrate
-    assert_equal "Stereo", tag.channel_mode
-    assert_equal 44100, tag.sample_rate
-    assert_equal 16, tag.bit_depth
-    assert file_io_closed?(tag)
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal 8, tag.duration.round
+      assert_equal 1411, tag.bitrate
+      assert_equal "Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_equal 16, tag.bit_depth
+    end
   end
 end

--- a/test/wahwah/tag_test.rb
+++ b/test/wahwah/tag_test.rb
@@ -12,51 +12,54 @@ class WahWah::TagTest < Minitest::Test
 
   def test_sub_class_not_implemented_parse_method
     assert_raises(WahWah::WahWahNotImplementedError) do
-      SubTag.new("test/files/id3v1.mp3")
+      File.open "test/files/id3v1.mp3", "rb" do |file|
+        SubTag.new(file)
+      end
     end
   end
 
   def test_have_necessary_attributes_method
-    tag = SubTagWithParse.new("test/files/id3v1.mp3")
+    File.open "test/files/id3v1.mp3", "rb" do |file|
+      tag = SubTagWithParse.new(file)
 
-    assert_respond_to tag, :title
-    assert_respond_to tag, :artist
-    assert_respond_to tag, :album
-    assert_respond_to tag, :albumartist
-    assert_respond_to tag, :composer
-    assert_respond_to tag, :comments
-    assert_respond_to tag, :track
-    assert_respond_to tag, :track_total
-    assert_respond_to tag, :duration
-    assert_respond_to tag, :file_size
-    assert_respond_to tag, :genre
-    assert_respond_to tag, :year
-    assert_respond_to tag, :disc
-    assert_respond_to tag, :disc_total
-    assert_respond_to tag, :images
-    assert_respond_to tag, :sample_rate
-    assert_respond_to tag, :bit_depth
-    assert_respond_to tag, :lyrics
-  end
-
-  def test_initialized_attributes
-    tag = SubTagWithParse.new("test/files/id3v1.mp3")
-
-    assert_equal File.size("test/files/id3v1.mp3"), tag.file_size
-    assert_equal [], tag.comments
-    assert_equal [], tag.images
-  end
-
-  def test_inspect
-    tag_inspect = SubTagWithParse.new("test/files/id3v1.mp3").inspect
-
-    WahWah::Tag::INTEGER_ATTRIBUTES.each do |attr_name|
-      assert_includes tag_inspect, "#{attr_name}="
+      assert_respond_to tag, :title
+      assert_respond_to tag, :artist
+      assert_respond_to tag, :album
+      assert_respond_to tag, :albumartist
+      assert_respond_to tag, :composer
+      assert_respond_to tag, :comments
+      assert_respond_to tag, :track
+      assert_respond_to tag, :track_total
+      assert_respond_to tag, :duration
+      assert_respond_to tag, :file_size
+      assert_respond_to tag, :genre
+      assert_respond_to tag, :year
+      assert_respond_to tag, :disc
+      assert_respond_to tag, :disc_total
+      assert_respond_to tag, :images
+      assert_respond_to tag, :sample_rate
+      assert_respond_to tag, :bit_depth
+      assert_respond_to tag, :lyrics
     end
   end
 
-  def test_closed
-    tag = SubTagWithParse.new("test/files/id3v1.mp3")
-    assert file_io_closed?(tag)
+  def test_initialized_attributes
+    File.open "test/files/id3v1.mp3", "rb" do |file|
+      tag = SubTagWithParse.new(file)
+
+      assert_equal file.size, tag.file_size
+      assert_equal [], tag.comments
+      assert_equal [], tag.images
+    end
+  end
+
+  def test_inspect
+    File.open "test/files/id3v1.mp3", "rb" do |file|
+      tag_inspect = SubTagWithParse.new(file).inspect
+
+      WahWah::Tag::INTEGER_ATTRIBUTES.each do |attr_name|
+        assert_includes tag_inspect, "#{attr_name}="
+      end
+    end
   end
 end

--- a/test/wahwah_test.rb
+++ b/test/wahwah_test.rb
@@ -22,13 +22,23 @@ class WahWahTest < Minitest::Test
     end
   end
 
+  def test_path_string_as_argument
+    tag = WahWah.open("test/files/id3v1.mp3")
+    assert_instance_of WahWah::Mp3Tag, tag
+    assert file_io_closed?(tag)
+  end
+
   def test_path_name_as_argument
-    assert_instance_of WahWah::Mp3Tag, WahWah.open(Pathname.new("test/files/id3v1.mp3"))
+    tag = WahWah.open(Pathname.new("test/files/id3v1.mp3"))
+    assert_instance_of WahWah::Mp3Tag, tag
+    assert file_io_closed?(tag)
   end
 
   def test_opened_file_as_argument
     File.open "test/files/id3v1.mp3", "rb" do |file|
-      assert_instance_of WahWah::Mp3Tag, WahWah.open(file)
+      tag = WahWah.open(file)
+      assert_instance_of WahWah::Mp3Tag, tag
+      assert !file.closed?
     end
   end
 

--- a/test/wahwah_test.rb
+++ b/test/wahwah_test.rb
@@ -26,6 +26,12 @@ class WahWahTest < Minitest::Test
     assert_instance_of WahWah::Mp3Tag, WahWah.open(Pathname.new("test/files/id3v1.mp3"))
   end
 
+  def test_opened_file_as_argument
+    File.open "test/files/id3v1.mp3", "rb" do |file|
+      assert_instance_of WahWah::Mp3Tag, WahWah.open(file)
+    end
+  end
+
   def test_support_formats
     assert_equal %w[mp3 ogg oga opus wav flac wma m4a].sort, WahWah.support_formats.sort
   end


### PR DESCRIPTION
I wish to be able to use WahWah in conjunction with [Down](https://github.com/janko/down) in order to read the tags from audio files hosted on the internet without downloading the entire files, as following:

```ruby
require "wahwah"
require "down"

stream = Down.open "https://github.com/obskyr/obscuriosities/raw/70a37bc126b8fe160ec2d137bec97bf69b2461dc/episodes/Episode%202%20-%20Mon%20Dieu,%20It's%20Jumping%20Flash%203-finished.ogg"
tags = WahWah.open stream
```

Given that the file in question isn't an ID3v1 file (which keeps the metadata at the *end* of the file; mamma mia), this would only require downloading the first kilobyte or so of the file! Handy, right?

However, as it stands, WahWah only supports supplying a path to a local file to `open`, since it uses the filename's extension to determine the filetype. The patch in this pull request migrates filetype detection to using the file signature instead (e.g. `ID3` for ID3v2; `fLaC` for FLAC…), and allows you to use already opened file objects (and file-like objects!) with WahWah. As an added bonus, it also enables WahWah to work with media files with unconventional extensions!

Since the rest of the code seemed to be more tightly coupled with filetype than with tag formats (e.g. `Mp3Tag` instead of, say, `Id3v2Tag`), I left that be, and extensions are still used internally at one point – but that's required on some level to keep `WahWah::support_formats` and thus preserve API compatibility, either way.

I've ensured that all the tests pass, as well as added a new test for using an already-opened file. Let me know if you'd like any changes, and I'd be happy to make them! 