### PR TITLE
Parse Ogg duration lazily to allow for streaming Oggs without downloading the whole file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,32 @@ tag.images      # => [{ :type => :cover_front, :mime_type => 'image/jpeg', :data
 
 WahWah.support_formats # => ["mp3", "ogg", "oga", "opus", "wav", "flac", "wma", "m4a"]
 ```
+
+### Streaming from an IO
+
+`WahWah.open` can also use already opened files and file-like IOs. When initialized this way, some tags will be lazily loaded, and the file will need to stay open while accessing a given tag for the first time. Calling `load_fully` will load all the tags eagerly.
+
+```ruby
+require "wahwah"
+
+File.open("/files/example.ogg") do |file|
+  tag = WahWah.open(file)
+  tag.duration # => 656.0 (in seconds)
+end
+
+
+# Or, this can be used to stream downloads! Lazy-loading is helpful here
+# because some formats require you to read to the end (and thus download the
+# whole file) to get certain data – e.g., ID3v1 has its metadata at the end,
+# and Ogg requires reading the whole file to calculate bitrate or duration.
+
+require "down"
+
+stream = Down.open("https://github.com/aidewoode/wahwah/raw/master/test/files/vorbis_tag.ogg")
+tag = WahWah.open(stream)
+tag.load_fully
+stream.close
+
+# Accessible after the stream was closed thanks to `load_fully`.
+tag.duration # => 8.0 (in seconds)
+```

--- a/lib/wahwah/lazy_tag_attributes.rb
+++ b/lib/wahwah/lazy_tag_attributes.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module WahWah
+  module LazyTagAttributes
+    def self.included(base)
+      base.extend ClassMethods
+
+      base.class_eval do
+        instance_variable_set :@_lazy_attributes, []
+
+        def self.inherited(subclass)
+          subclass.class_eval do
+            instance_variable_set :@_lazy_attributes, subclass.superclass._lazy_attributes.dup
+          end
+        end
+      end
+    end
+
+    def load_fully
+      self.class._lazy_attributes.each do |name|
+        send name
+      end
+      nil
+    end
+
+    module ClassMethods
+      def _lazy_attributes
+        @_lazy_attributes
+      end
+
+      # Adapted from https://www.gregnavis.com/articles/lazy-attributes-in-ruby.html
+      def lazy(name, if_closed = nil, &definition)
+        variable_name = :"@#{name}"
+        @_lazy_attributes.push name
+
+        define_method(name) do
+          if instance_variable_defined? variable_name
+            instance_variable_get variable_name
+          else
+            result = begin
+              instance_eval(&definition)
+            rescue => error
+              # We want to let parsing errors result in default values,
+              # but if the user attempts to read a lazy property from
+              # a file that's closed, that error should go through.
+              raise if error.is_a? IOError
+              if_closed
+            end
+            instance_variable_set variable_name, result
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/wahwah/tag.rb
+++ b/lib/wahwah/tag.rb
@@ -2,6 +2,8 @@
 
 module WahWah
   class Tag
+    include LazyTagAttributes
+
     INTEGER_ATTRIBUTES = %i[disc disc_total track track_total]
     INSPECT_ATTRIBUTES = %i[title artist album albumartist composer track track_total genre year disc disc_total duration bitrate sample_rate bit_depth]
 
@@ -43,13 +45,19 @@ module WahWah
 
     def inspect
       inspect_id = ::Kernel.format "%x", (object_id * 2)
-      inspect_attributes_values = INSPECT_ATTRIBUTES.map { |attr_name| "#{attr_name}=#{send(attr_name)}" }.join(" ")
+      inspect_attributes_values = INSPECT_ATTRIBUTES.map do |attr_name|
+        if self.class._lazy_attributes.include? attr_name
+          "#{attr_name}=<unloaded>"
+        else
+          "#{attr_name}=#{send(attr_name)}"
+        end
+      end.join(" ")
 
       "<#{self.class.name}:0x#{inspect_id} #{inspect_attributes_values}>"
     end
 
-    def images
-      return @images_data if @images_data.empty?
+    lazy :images, [] do
+      next @images_data if @images_data.empty?
 
       @images_data.map do |data|
         parse_image_data(data)

--- a/test/wahwah/ogg_tag_test.rb
+++ b/test/wahwah/ogg_tag_test.rb
@@ -68,4 +68,81 @@ class WahWah::OggTagTest < Minitest::Test
       assert_equal "I'm feeling tragic like I'm Marlon Brando", tag.lyrics
     end
   end
+
+  def test_lazy_duration
+    File.open("test/files/vorbis_tag.ogg", "rb") do |file|
+      tag = WahWah::OggTag.new(file)
+      assert tag.instance_variable_get(:@file_io).pos < file.size
+      assert !tag.instance_variable_get(:@duration)
+      tag.duration
+      assert tag.instance_variable_get(:@file_io).pos == file.size
+      assert tag.instance_variable_get(:@duration)
+    end
+  end
+
+  def test_lazy_bitrate
+    File.open("test/files/vorbis_tag.ogg", "rb") do |file|
+      tag = WahWah::OggTag.new(file)
+      assert tag.instance_variable_get(:@file_io).pos < file.size
+      assert !tag.instance_variable_get(:@bitrate)
+      tag.bitrate
+      assert tag.instance_variable_get(:@bitrate)
+    end
+  end
+
+  def test_ogg_load_fully_file_that_stays_open
+    File.open("test/files/vorbis_tag.ogg", "rb") do |file|
+      tag = WahWah::OggTag.new(file)
+      assert_equal tag.duration, 8.0
+      assert_equal tag.bitrate, 192
+      assert_equal tag.images, []
+      assert_nil tag.load_fully
+      assert !file_io_closed?(tag)
+    end
+  end
+
+  def test_ogg_load_fully_file_that_closes
+    begin
+      file = File.open("test/files/vorbis_tag.ogg", "rb")
+      tag = WahWah.open(file)
+      assert_nil tag.load_fully
+    ensure
+      file.close
+    end
+    assert file_io_closed?(tag)
+    assert_equal tag.duration, 8.0
+    assert_equal tag.bitrate, 192
+    assert_equal tag.images, []
+  end
+
+  def test_ogg_load_fully_failure
+    begin
+      file = File.open("test/files/vorbis_tag.ogg", "rb")
+      tag = WahWah.open(file)
+    ensure
+      file.close
+    end
+    assert file_io_closed?(tag)
+    assert_raises(IOError) do
+      assert_nil tag.load_fully
+    end
+  end
+
+  def test_ogg_lazy_failures
+    # #bitrate and #images are also lazy attributes and *may* be lazily parsed,
+    # but it depends on the tag delegate. Only the duration of an Ogg Vorbis
+    # file always requires reading to near the end of the file.
+    should_fail = [:duration]
+    file = File.open("test/files/vorbis_tag.ogg")
+    begin
+      tag = WahWah.open(file)
+    ensure
+      file.close
+    end
+    should_fail.each do |name|
+      assert_raises(IOError, "Not loaded lazily or did not raise error: OggTag##{name}") do
+        tag.send(name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the second part to my pull request #40 – thank you for facilitating that, and for all your lovely feedback!

Building on the ability to supply IO objects directly to WahWah, this pull request changes the behavior slightly so that when a WahWah object is initialized using an existing IO (and only then), some tags are loaded lazily. This allows files to be streamed from the internet without downloading more than needed! The behavior remains unchanged when supplying a path, so this is not a breaking change in relation to the latest release.

Also added in this pull request is `Tag#load_fully`, which allows the user to load all the tags eagerly, in case they wish to avoid this behavior. An example:

```ruby
require "down"

stream = Down.open("https://github.com/aidewoode/wahwah/raw/master/test/files/vorbis_tag.ogg")
tag = WahWah.open(stream)
tag.duration # => 8.0
stream.close
tag.duration # => 8.0 – Accessible after the stream was closed thanks to being cached from the previous access


stream = Down.open("https://github.com/aidewoode/wahwah/raw/master/test/files/vorbis_tag.ogg")
tag = WahWah.open(stream)
tag.load_fully
stream.close

# Accessible after the stream was closed thanks to `load_fully`.
tag.duration # => 8.0


stream = Down.open("https://github.com/aidewoode/wahwah/raw/master/test/files/vorbis_tag.ogg")
tag = WahWah.open(stream)
stream.close

tag.duration # => IOError! No longer open for reading.

```

The only tags loaded lazily as of this pull request are the duration and bitrate of Oggs, as they require reading to the end of the file – I don't see a need to make *all* tags lazy-loaded, as the gain is negligible for metadata that appears near the start of the file. The lazy-loading facilities, found in `/lib/wahwah/lazy_tag_attributes.rb`, are however generic and reusable, so they can easily be applied to other formats should it turn out to be helpful for any other format.