### PR TITLE
Add in ftyp3gp4 as valid signature for m4a

### DIFF
--- a/lib/wahwah/helper.rb
+++ b/lib/wahwah/helper.rb
@@ -60,7 +60,7 @@ module WahWah
       # M4A is checked for first, since MP4 files start with a chunk size -
       # and that chunk size may incidentally match another signature.
       # No other formats would reasonably have "ftyp" as the next for bytes.
-      return "m4a" if signature[4...12] == "ftypM4A ".b
+      return "m4a" if ["ftypM4A ".b, "ftyp3gp4".b].include?(signature[4...12])
       # Handled separately simply because it requires two checks.
       return "wav" if signature.start_with?("RIFF".b) && signature[8...12] == "WAVE".b
       magic_numbers = {

--- a/lib/wahwah/version.rb
+++ b/lib/wahwah/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WahWah
-  VERSION = "1.6.3"
+  VERSION = "1.6.4"
 end


### PR DESCRIPTION
Samsung Recorder app apparently saves M4As with a 3GP4 codec (see: https://android.stackexchange.com/questions/252811/m4a-audio-files-not-recognized-by-samsung-recorder-app) which gives the m4a file a signature of `ftyp3gp4`.

Unfortunately the only files I could test with were files I can't add to tests for privacy reasons (and I unfortunately don't have a Samsung or an Android), but by adding this byte in, more M4As could indeed be read correctly now by `WahWah`.