### PR TITLE
Fix wav files not being rewound, such as when they are missing their file extension

### DIFF
--- a/lib/wahwah/helper.rb
+++ b/lib/wahwah/helper.rb
@@ -54,6 +54,8 @@ module WahWah
     def self.file_format_from_signature(io)
       io.rewind
       signature = io.read(16)
+      # Rewind after reading the signature to not mess with the file position
+      io.rewind
 
       # Source: https://en.wikipedia.org/wiki/List_of_file_signatures
 

--- a/lib/wahwah/riff_tag.rb
+++ b/lib/wahwah/riff_tag.rb
@@ -41,6 +41,7 @@ module WahWah
     private
 
     def parse
+      @file_io.rewind
       top_chunk = Riff::Chunk.new(@file_io)
       return unless top_chunk.valid?
 

--- a/lib/wahwah/riff_tag.rb
+++ b/lib/wahwah/riff_tag.rb
@@ -41,7 +41,6 @@ module WahWah
     private
 
     def parse
-      @file_io.rewind
       top_chunk = Riff::Chunk.new(@file_io)
       return unless top_chunk.valid?
 

--- a/lib/wahwah/tag.rb
+++ b/lib/wahwah/tag.rb
@@ -31,6 +31,9 @@ module WahWah
       @file_size = io.size
       @file_io = io
 
+      # Rewinding at the start just in case some other helper class or parser already read from the file
+      @file_io.rewind
+
       @comments = []
       @images_data = []
 

--- a/lib/wahwah/version.rb
+++ b/lib/wahwah/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WahWah
-  VERSION = "1.6.4"
+  VERSION = "1.6.5"
 end

--- a/test/wahwah/riff_tag_test.rb
+++ b/test/wahwah/riff_tag_test.rb
@@ -66,4 +66,25 @@ class WahWah::RiffTagTest < Minitest::Test
       assert_equal 16, tag.bit_depth
     end
   end
+
+  def test_tag_works_with_file_missing_extension
+    blob_data = binary_data("test/files/id3v2.wav")
+
+    Tempfile.create("temp-audio-file", binmode: true) do |temp_file|
+      temp_file.write blob_data
+      tag = WahWah::RiffTag.new(temp_file)
+
+      assert_equal "China Girl", tag.title
+      assert_equal "Iggy Pop", tag.artist
+      assert_equal "The Idiot", tag.album
+      assert_equal "1977", tag.year
+      assert_equal "Rock", tag.genre
+      assert_equal ["Iggy Pop Rocks"], tag.comments
+      assert_equal 8.001133947554926, tag.duration
+      assert_equal 1411, tag.bitrate
+      assert_equal "Stereo", tag.channel_mode
+      assert_equal 44100, tag.sample_rate
+      assert_equal 16, tag.bit_depth
+    end
+  end
 end


### PR DESCRIPTION
If a file doesn't have an extension, `WahWah` will attempt to understand the format from the signature:

```ruby
def self.file_format_from_signature(io)
  io.rewind
  signature = io.read(16)

  # ...
end
```

This moves the position of the IO, but `parse` within `RiffTag` doesn't take this into account.

To fix this, I do `@file_io.rewind` at the begining of `parse` within `RiffTag` now.

Strangely, I was surprised this didn't affect other tags -- if `file_format_from_signature` was moving the position, wouldn't this not just affect `RiffTag`?

Looking around, I guess the answer was "no" -- `Mp3Tag` rewinds at the start via `parse_id3_tag`, `FlacTag` conditionally rewinds, and `Mp4Tag` seems to seek to some known attributes.

I still wonder if there's some issues with this other places, but for now this at least fixes `RiffTag`.