### PR TITLE
Adding a few more parsing fixes for various M4A and MP3 file types

### DIFF
--- a/lib/wahwah/helper.rb
+++ b/lib/wahwah/helper.rb
@@ -62,7 +62,7 @@ module WahWah
       # M4A is checked for first, since MP4 files start with a chunk size -
       # and that chunk size may incidentally match another signature.
       # No other formats would reasonably have "ftyp" as the next for bytes.
-      return "m4a" if ["ftypM4A ".b, "ftyp3gp4".b].include?(signature[4...12])
+      return "m4a" if ["ftypM4A ".b, "ftyp3gp4".b, "ftypmp42".b].include?(signature[4...12])
       # Handled separately simply because it requires two checks.
       return "wav" if signature.start_with?("RIFF".b) && signature[8...12] == "WAVE".b
       magic_numbers = {

--- a/lib/wahwah/mp3_tag.rb
+++ b/lib/wahwah/mp3_tag.rb
@@ -52,6 +52,7 @@ module WahWah
     def parse_id3_tag
       @file_io.rewind
       signature = @file_io.read(6)
+      @file_io.rewind
 
       if signature.start_with?("ID3".b)
         id3_v2_tag = ID3::V2.new(@file_io)
@@ -72,7 +73,7 @@ module WahWah
         @bitrate = (bytes_count * 8 / @duration / 1000).round unless @duration.zero?
       else
         @bitrate = mpeg_frame_header.frame_bitrate
-        @duration = (file_size - (@id3_tag&.size || 0)) * 8 / (@bitrate * 1000).to_f unless @bitrate.zero?
+        @duration = (file_size - (@id3_tag&.size || 0)) * 8 / (@bitrate * 1000).to_f unless @bitrate.to_i.zero?
       end
     end
 

--- a/lib/wahwah/version.rb
+++ b/lib/wahwah/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WahWah
-  VERSION = "1.6.5"
+  VERSION = "1.6.6"
 end


### PR DESCRIPTION
Another round of small fixes, this time in a couple different areas:

- With MP3s that have a weird bitrate, or possibly are not rewound
- With MP4s and the `ftypmp42` signature