### PR TITLE
require "pathname"

### DIFF
--- a/lib/wahwah.rb
+++ b/lib/wahwah.rb
@@ -3,6 +3,7 @@
 require "stringio"
 require "forwardable"
 require "zlib"
+require "pathname"
 
 require "wahwah/version"
 require "wahwah/errors"


### PR DESCRIPTION
Notice that this will fail on Ruby 3.2:

```shell
ruby -rwahwah -e 'WahWah.open("test.ogg").duration'
```

```
/home/ulysses/.local/share/gem/ruby/3.2.0/gems/wahwah-1.6.6/lib/wahwah.rb:82:in `with_io': uninitialized constant WahWah::Pathname (NameError)

    if path_or_io.is_a? Pathname
                        ^^^^^^^^
	from /home/ulysses/.local/share/gem/ruby/3.2.0/gems/wahwah-1.6.6/lib/wahwah.rb:64:in `open'
	from -e:1:in `block in <main>'
	from -e:1:in `open'
	from -e:1:in `<main>'
```